### PR TITLE
Add federation to products service

### DIFF
--- a/products/src/main/scala/com/williamhaw/gql_caliban/products/ProductsServer.scala
+++ b/products/src/main/scala/com/williamhaw/gql_caliban/products/ProductsServer.scala
@@ -26,13 +26,14 @@ object ProductsServer extends App {
   def topProducts(args: TopArgs): Seq[Product] = products.slice(0, args.first)
 
   case class TopArgs(first: Int)
+  case class ProductArgs(upc: String)
 
   case class Queries(topProducts: TopArgs => Seq[Product])
 
   val queries: Queries = Queries(args => topProducts(args))
 
   val api = graphQL(RootResolver(queries)) @@ federated(
-    EntityResolver.from[TopArgs](args => ZQuery.fromEffect(UIO(Some(topProducts(args)))))
+    EntityResolver.from[ProductArgs](args => ZQuery.fromEffect(UIO(products.find(_.upc == args.upc))))
   )
 
   implicit val system: ActorSystem                        = ActorSystem()

--- a/products/src/main/scala/com/williamhaw/gql_caliban/products/ProductsServer.scala
+++ b/products/src/main/scala/com/williamhaw/gql_caliban/products/ProductsServer.scala
@@ -7,7 +7,8 @@ import caliban.GraphQL.graphQL
 import caliban.federation._
 import caliban.{AkkaHttpAdapter, RootResolver}
 import sttp.tapir.json.play._
-import zio.Runtime
+import zio.{Runtime, UIO}
+import zio.query.ZQuery
 
 import scala.concurrent.ExecutionContextExecutor
 
@@ -30,7 +31,9 @@ object ProductsServer extends App {
 
   val queries: Queries = Queries(args => topProducts(args))
 
-  val api = graphQL(RootResolver(queries))
+  val api = graphQL(RootResolver(queries)) @@ federated(
+    EntityResolver.from[TopArgs](args => ZQuery.fromEffect(UIO(Some(topProducts(args)))))
+  )
 
   implicit val system: ActorSystem                        = ActorSystem()
   implicit val executionContext: ExecutionContextExecutor = system.dispatcher


### PR DESCRIPTION
Figured it out; the entity resolver is not a copy of the normal resolvers, it is for lookup of entities from other services.

This change results in the following exception:
```
Exception in thread "main" zio.FiberFailure: Fiber failed.
A checked error was not handled.
ValidationError Error: Union _Entity contains the following non Object types: .
	at caliban.validation.Validator$.$anonfun$failValidation$1(Validator.scala:54)
	at zio.ZIO$.$anonfun$fail$1(ZIO.scala:2898)
	at zio.internal.FiberContext.evaluateNow(FiberContext.scala:413)
	at zio.Runtime.unsafeRunWith(Runtime.scala:221)
	at zio.Runtime.unsafeRunSync(Runtime.scala:84)
	at zio.Runtime.unsafeRunSync$(Runtime.scala:81)
	at zio.Runtime$$anon$3.unsafeRunSync(Runtime.scala:288)
	at zio.Runtime.unsafeRun(Runtime.scala:59)
	at zio.Runtime.unsafeRun$(Runtime.scala:58)
	at zio.Runtime$$anon$3.unsafeRun(Runtime.scala:288)
	at com.williamhaw.gql_caliban.products.ProductsServer$.delayedEndpoint$com$williamhaw$gql_caliban$products$ProductsServer$1(ProductsServer.scala:42)
	at com.williamhaw.gql_caliban.products.ProductsServer$delayedInit$body.apply(ProductsServer.scala:15)
	at scala.Function0.apply$mcV$sp(Function0.scala:39)
	at scala.Function0.apply$mcV$sp$(Function0.scala:39)
	at scala.runtime.AbstractFunction0.apply$mcV$sp(AbstractFunction0.scala:17)
	at scala.App.$anonfun$main$1(App.scala:76)
	at scala.App.$anonfun$main$1$adapted(App.scala:76)
	at scala.collection.IterableOnceOps.foreach(IterableOnce.scala:563)
	at scala.collection.IterableOnceOps.foreach$(IterableOnce.scala:561)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:926)
	at scala.App.main(App.scala:76)
	at scala.App.main$(App.scala:74)
	at com.williamhaw.gql_caliban.products.ProductsServer$.main(ProductsServer.scala:15)
	at com.williamhaw.gql_caliban.products.ProductsServer.main(ProductsServer.scala)

Fiber:Id(1641314117896,0) was supposed to continue to:
  a future continuation at caliban.validation.Validator$.validateSchema(Validator.scala:38)
  a future continuation at caliban.validation.Validator$.validateSchema(Validator.scala:39)
  a future continuation at caliban.validation.Validator$.validateSchema(Validator.scala:40)
  a future continuation at caliban.GraphQL.interpreter(GraphQL.scala:66)
  a future continuation at com.williamhaw.gql_caliban.products.ProductsServer$.interpreter(ProductsServer.scala:42)

Fiber:Id(1641314117896,0) execution trace:
  at zio.ZIO$.foreach_(ZIO.scala:3103)
  at zio.ZIO$.foreach_(ZIO.scala:3103)
  at zio.ZIO$.foreach_(ZIO.scala:3103)
  at zio.ZIO$.foreach_(ZIO.scala:3103)
  at zio.ZIO$.foreach_(ZIO.scala:3105)
  at zio.ZIO$.foreach_(ZIO.scala:3101)

Fiber:Id(1641314117896,0) was spawned by: <empty trace>
```
